### PR TITLE
bug/eugene/datless/need-to-make-objects-hashable

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -29,12 +29,12 @@ def other_datasource():
 
 @pytest.fixture
 def company():
-    return Company("id", "ticker", "name", "uri", None)
+    return Company("1", "ticker", "name", "uri", None)
 
 
 @pytest.fixture
 def other_company():
-    return Company("other_id", "other_ticker", "other_name", "other_uri", None)
+    return Company("2", "other_ticker", "other_name", "other_uri", None)
 
 
 @pytest.fixture

--- a/datamonster_api/lib/company.py
+++ b/datamonster_api/lib/company.py
@@ -26,6 +26,9 @@ class Company(BaseClass):
         ticker_str = "[{}] ".format(self.ticker) if self.ticker else ""
         return "<{}: {}{}>".format(self.__class__.__name__, ticker_str, self.name)
 
+    def __hash__(self):
+        return int(self.id)
+
     def __eq__(self, obj):
         return isinstance(obj, Company) and self.id == obj.id
 

--- a/datamonster_api/lib/datasource.py
+++ b/datamonster_api/lib/datasource.py
@@ -20,6 +20,9 @@ class Datasource(BaseClass):
         self.uri = uri
         self.dm = dm
 
+    def __hash__(self):
+        return hash(self.id)
+
     def __eq__(self, obj):
         return isinstance(obj, Datasource) and self.id == obj.id
 

--- a/datamonster_api/tests/lib/test_company.py
+++ b/datamonster_api/tests/lib/test_company.py
@@ -14,6 +14,12 @@ def test_equality(company, other_company):
     assert company == company
     assert other_company != company
 
+    d = {}
+    d[company] = 1
+    d[other_company] = 2
+    assert len(d) == 2
+    assert d[company] == 1
+
 
 def test_get_companies_1(mocker, dm, single_page_company_results, datasource):
 

--- a/datamonster_api/tests/lib/test_datamonster.py
+++ b/datamonster_api/tests/lib/test_datamonster.py
@@ -17,6 +17,12 @@ def test_equality(datasource, other_datasource):
     assert datasource == datasource
     assert other_datasource != datasource
 
+    d = {}
+    d[datasource] = 1
+    d[other_datasource] = 2
+    assert len(d) == 2
+    assert d[datasource] == 1
+
 
 def test_datamonster_datasource_mapper():
     from pandas.util.testing import assert_frame_equal


### PR DESCRIPTION
from the docs:
https://docs.python.org/3/reference/datamodel.html#object.__hash__
```
If a class does not define an __eq__() method it should not define a __hash__() operation either; if it defines __eq__() but not __hash__(), its instances will not be usable as items in hashable collections. If a class defines mutable objects and implements an __eq__() method, it should not implement __hash__(), since the implementation of hashable collections requires that a key’s hash value is immutable (if the object’s hash value changes, it will be in the wrong hash bucket).```